### PR TITLE
Updates for new-user-friendliness

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,44 @@ It's open source, using GPL 3.0 license, and it takes great inspiration from [@l
 ## Installation
 
 Copy the script to a path on your Openwrt router. I recommend using ssh. \
+You may also download it directly from GitHub to your router: `wget https://raw.githubusercontent.com/ksorio/ddns-script-porkbun/main/update_porkbun.sh` \
 Remember to give execute permission to the script: `chmod +x update_porkbun.sh`.
 
-## Usage
+## Usage (LuCI web GUI)
 
-TODO
+- Install the LuCI DDNS web GUI using `opkg install luci-app-ddns` and open `<YOUR_ROUTER>/cgi-bin/luci/admin/services/ddns`.
+- Click "Add new services"; give it a name (like "porkbun") and choose the "-- custom --" provider.
+- Edit the entry and set the following fields:
+  - `Lookup Hostname` => your domain name
+  - `Custom update-script` => the path to update_porkbun.sh on your router
+  - `Domain` => your domain name
+  - `Username` => Your Porkbun API key (not the secret!)
+  - `Password` => Your Porkbun API secret
+  - (optional) `Optional Parameter` => your desired TTL (must be >= 600)
+  - (optional) `Use HTTP Secure` => true
+  - (optional) `Path to CA-Certificate` => /etc/ssl/certs
+- Configure anything else to your liking, then click Save
+
+## Usage (command line)
+
+Sample config section (you may choose different values for some, but fields with UPPERCASE values require your input):
+
+```
+config service 'porkbun'
+        option enabled '1'
+        option domain 'YOUR_DOMAIN'
+        option lookup_host 'YOUR_DOMAIN'
+        option update_script 'PATH_TO_UPDATE_SCRIPT'
+        option username 'YOUR_PORKBUN_API_KEY'
+        option password 'YOUR_PORKBUN_API_KEY_SECRET'
+        option use_https '1'
+        option cacert '/etc/ssl/certs'
+        option ip_source 'network'
+        option ip_network 'wan'
+        option interface 'wan'
+        option param_opt '600'
+```
+
+The `param_opt` value controls the TTL value sent to Porkbun (in seconds). The minimum they will accept is 600; trying to use anything lower will result in the actual value being set to 600.
+
+You can manually try a test run with: `/usr/lib/ddns/dynamic_dns_updater.sh -S porkbun -v1 start`

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ It's open source, using GPL 3.0 license, and it takes great inspiration from [@l
 - A dynamic public IP address (either IPv4 or IPv6).
 - Porkbun API's public and secret key.
 - Porkbun API activated for the domain you want to use.
+- An existing `A` record on your domain (you should delete the `CNAME` and `ALIAS` records they start new domains with).
 - Curl, can be installed using `opkg install curl`.
 - (If using HTTPS) System CA certificates, can be installed using `opkg install ca-certificates`.
 

--- a/update_porkbun.sh
+++ b/update_porkbun.sh
@@ -30,7 +30,7 @@
 rrvalue=$__IP
 
 # The value for the TTL of the resource record
-if [[ -z $param_opt ]]; then
+if [[ -z "$param_opt" ]]; then
    rrttl=$param_opt
 else
    rrttl=600
@@ -39,17 +39,17 @@ fi
 # Domain and subdomain
 real_domain=$(echo $domain | grep -oE [a-zA-Z0-9]+\.[a-zA-Z0-9]+$)
 subdomain=${domain%".$real_domain"}
-if [[ $real_domain == $subdomain ]]; then
+if [[ "$real_domain" == "$subdomain" ]]; then
    subdomain=
 fi
 
-# Get Porkbun's current resource record 
+# Get Porkbun's current resource record
 old_rrvalue=$(curl -s -X POST "https://porkbun.com/api/json/v3/dns/retrieveByNameType/$real_domain/$rrtype/$subdomain" -H "Content-Type: application/json" --data "{ \"apikey\": \"$username\", \"secretapikey\": \"$password\" }" | grep -oE 'content":"([0-9.]+|[0-9a-fA-F:]+)"' | grep -oE '"([0-9][0-9.]+|[0-9a-fA-F][0-9a-fA-F:]+)"' | grep -oE '[0-9.]+|[0-9a-fA-F:]+')
 
 write_log 7 "Current IP for the domain is: $old_rrvalue"
 
 # Update resource record if necessary
-if [[ $old_rrvalue != $rrvalue ]]; then
+if [[ "$old_rrvalue" != "$rrvalue" ]]; then
    write_log 7 "Updating DNS value because $old_rrvalue != $rrvalue"
    curl -X POST "https://porkbun.com/api/json/v3/dns/editByNameType/$real_domain/$rrtype/$subdomain" -H "Content-Type: application/json" --data "{ \"apikey\": \"$username\", \"secretapikey\": \"$password\", \"content\": \"$rrvalue\", \"type\": \"$rrtype\", \"ttl\": \"$rrttl\"}"
 else


### PR DESCRIPTION
First off, thanks for writing this! I just got my own new domain set up using this script, and wanted to contribute back what I learned during the setup process. A few comments on my commits here:

1. My new domain had no `A` records yet, so `old_rrvalue` was empty, leading to an "unknown operand" error when comparing with `rrvalue`. Adding quotes around string arguments eliminates the error in this case, though I think you still need to manually add the first `A` record. Their API was reporting success but never seemed to actually write `A` record values until after I'd manually added one in the dashboard. Or maybe deleting the initial `CNAME` and `ALIAS` records is what fixed that, I'm not sure.
2. It wasn't too hard to figure out how to get this script working with OpenWrt, but it wasn't obvious either (for a newcomer like myself at least), so I took the liberty of adding "usage" sections to the README based on my experience getting it working on my router + domain. Hopefully this helps someone else!