### PR TITLE
Support Porkbun API hostname change

### DIFF
--- a/update_porkbun.sh
+++ b/update_porkbun.sh
@@ -44,14 +44,14 @@ if [[ "$real_domain" == "$subdomain" ]]; then
 fi
 
 # Get Porkbun's current resource record
-old_rrvalue=$(curl -s -X POST "https://porkbun.com/api/json/v3/dns/retrieveByNameType/$real_domain/$rrtype/$subdomain" -H "Content-Type: application/json" --data "{ \"apikey\": \"$username\", \"secretapikey\": \"$password\" }" | grep -oE 'content":"([0-9.]+|[0-9a-fA-F:]+)"' | grep -oE '"([0-9][0-9.]+|[0-9a-fA-F][0-9a-fA-F:]+)"' | grep -oE '[0-9.]+|[0-9a-fA-F:]+')
+old_rrvalue=$(curl -s -X POST "https://api.porkbun.com/api/json/v3/dns/retrieveByNameType/$real_domain/$rrtype/$subdomain" -H "Content-Type: application/json" --data "{ \"apikey\": \"$username\", \"secretapikey\": \"$password\" }" | grep -oE 'content":"([0-9.]+|[0-9a-fA-F:]+)"' | grep -oE '"([0-9][0-9.]+|[0-9a-fA-F][0-9a-fA-F:]+)"' | grep -oE '[0-9.]+|[0-9a-fA-F:]+')
 
 write_log 7 "Current IP for the domain is: $old_rrvalue"
 
 # Update resource record if necessary
 if [[ "$old_rrvalue" != "$rrvalue" ]]; then
    write_log 7 "Updating DNS value because $old_rrvalue != $rrvalue"
-   curl -X POST "https://porkbun.com/api/json/v3/dns/editByNameType/$real_domain/$rrtype/$subdomain" -H "Content-Type: application/json" --data "{ \"apikey\": \"$username\", \"secretapikey\": \"$password\", \"content\": \"$rrvalue\", \"type\": \"$rrtype\", \"ttl\": \"$rrttl\"}"
+   curl -X POST "https://api.porkbun.com/api/json/v3/dns/editByNameType/$real_domain/$rrtype/$subdomain" -H "Content-Type: application/json" --data "{ \"apikey\": \"$username\", \"secretapikey\": \"$password\", \"content\": \"$rrvalue\", \"type\": \"$rrtype\", \"ttl\": \"$rrttl\"}"
 else
    write_log 7 "No need to update DNS value."
 fi


### PR DESCRIPTION
Small change to account for Porkbun moving the api from https://porkbun.com to https://api.porkbun.com. The cutoff for the old hostname endpoint has been announced to be Dec 1 2024.

This is installed and running on my router but has only received minimal testing.